### PR TITLE
BUGFIX: Do not use NODE_ENV in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
-if (process.env.NODE_ENV === 'development') {
+// NOTE BRN: We use a custom env variable here instead of NODE_ENV because when
+// this binary is loaded for development by another application they may have
+// set their NODE_ENV to "development" but have installed this module for
+// production usage
+if (process.env.MOLTRES_CLI_TEST) {
   require('@babel/register')(require('./babel.config'))
   module.exports = require('./src')
 } else {

--- a/src/lang/index.js
+++ b/src/lang/index.js
@@ -1,5 +1,6 @@
 export * from './constants'
 
+export { default as __ } from './__'
 export { default as addIndex } from './addIndex'
 export { default as all } from './all'
 export { default as always } from './always'


### PR DESCRIPTION
This PR...
- [x] fixes a bug in the index file where we were using babel-register when `NODE_ENV==='development'`. This broke production usage of the binary since an app developer is likely to set this value but the module should be executing in production mode.
- [x] Exports the `__` from lang