### PR TITLE
Inherit stdio to preserve command output formmating

### DIFF
--- a/bin/moltres-run
+++ b/bin/moltres-run
@@ -23,17 +23,8 @@ const exec = async ({ args, stage }) => {
       ...process.env,
       ...env,
       STAGE: stage
-    }
-  })
-
-  spawn.stdout.on('data', (data) => {
-    // eslint-disable-next-line no-console
-    console.log(data.toString())
-  })
-
-  spawn.stderr.on('data', (data) => {
-    // eslint-disable-next-line no-console
-    console.error(data.toString())
+    },
+    stdio: 'inherit'
   })
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR...
- [x] Switches the run command to inherit stdio so that we preserve CLI output formatting from the scripts run by the `moltres run` command.