### PR TITLE
Fix projectId when running on local stage

### DIFF
--- a/src/config/generateProjectId.js
+++ b/src/config/generateProjectId.js
@@ -14,9 +14,11 @@ const generateProjectId = (config = {}) => {
     return slice(0, 30, `test-${config.test.runId}`)
   }
 
-  if (config.stage === 'local') {
-    return 'local'
-  }
+  // NOTE BRN: We couldn't do this because the emulator requires that the
+  // projectId match the actual project in order to show data
+  // if (config.stage === 'local') {
+  //   return 'local'
+  // }
 
   invariant(
     process.env.FIREBASE_PROJECT_ID,


### PR DESCRIPTION
This PR...
- [x] Fixes a bug when running on local state where the projectId must match the configured firebase project in order for the emulator UI to work.